### PR TITLE
Improve site SEO foundations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,19 +1,40 @@
 theme: jekyll-theme-minimal
 repository: mithunshanbhag/mithunshanbhag.github.io
 logo: images/logo_400_400.jpg
+lang: en-US
 
 # 
 author: 
   name: Mithun Shanbhag
+  bio: Bangalore-based software architect, SaaS builder, and technical writer.
+  location: Bengaluru, India
   github: https://github.com/mithunshanbhag
   linkedin: https://www.linkedin.com/in/mithunshanbhag/
   twitter: https://twitter.com/MithunShanbhag
   
+social:
+  name: Mithun Shanbhag
+  links:
+    - https://github.com/mithunshanbhag
+    - https://www.linkedin.com/in/mithunshanbhag/
+    - https://twitter.com/MithunShanbhag
+    - https://www.cloudskew.com
+
+twitter:
+  username: MithunShanbhag
+  card: summary_large_image
 
 # SEO related
 title: Mithun Shanbhag
-description: Is anyone actually reading this?
+description: Bangalore-based software architect, SaaS builder, and technical writer writing about .NET, Azure, software architecture, developer productivity, and AI-assisted product ideas.
 url: https://www.mithunshanbhag.com
+social_image: /images/logo_400_400.jpg
+expertise:
+  - .NET
+  - Microsoft Azure
+  - Software architecture
+  - SaaS product development
+  - AI-assisted product workflows
 
 # 
 plugins:
@@ -23,6 +44,10 @@ plugins:
   - jekyll-sitemap
 
 defaults:
+  - scope:
+      path: ""
+    values:
+      image: /images/logo_400_400.jpg
   - scope:
       path: ""
       type: posts

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -12,27 +12,44 @@
     <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
     <![endif]-->
   {% seo %}
+  {% assign social_image = page.image | default: site.social_image %}
+  {% if social_image %}
+  <meta property="og:image" content="{{ social_image | absolute_url }}">
+  <meta name="twitter:image" content="{{ social_image | absolute_url }}">
+  {% endif %}
 </head>
 
 <body>
   <div class="wrapper">
-    <header>
-      <h1><a href="{{ "/" | absolute_url }}">{{ site.author.name }}</a></h1>
-      <p>(<a href="/">blog</a> | <a href="/feed.xml">rss</a> | <a href="{{site.author.twitter}}">twitter</a> | <a
-          href="{{site.author.linkedin}}">linkedin</a> | <a href="{{site.author.github}}">github)</a> </p>
+    <header class="site-header">
+      <p class="site-title"><a href="{{ "/" | relative_url }}">{{ site.author.name }}</a></p>
+      <p class="site-tagline">{{ site.author.bio }}</p>
+      <nav class="site-nav" aria-label="Primary">
+        <a href="{{ "/about/" | relative_url }}">About</a>
+        <a href="{{ "/projects/" | relative_url }}">Projects</a>
+        <a href="{{ "/writing/" | relative_url }}">Writing</a>
+        <a href="{{ "/speaking/" | relative_url }}">Speaking</a>
+        <a href="{{ "/feed.xml" | relative_url }}">RSS</a>
+      </nav>
+      <p class="social-links">
+        <a href="{{ site.author.twitter }}">X</a>
+        <span aria-hidden="true">&middot;</span>
+        <a href="{{ site.author.linkedin }}">LinkedIn</a>
+        <span aria-hidden="true">&middot;</span>
+        <a href="{{ site.author.github }}">GitHub</a>
+      </p>
 
       {% if site.logo %}
-      <img src="{{site.logo | relative_url}}" alt="Logo" />
+      <img class="site-logo" src="{{site.logo | relative_url}}" alt="{{ site.author.name }}" width="400" height="400" />
       {% endif %}
 
-      <br>
-      <br>
-      <br>
-
-      <h3>Quick links</h3>
-      <p><a href="https://www.cloudskew.com">cloudskew.com</a></p>
-      <p><a href="/2019/06/19/speaking-engagements">my speaking engagements</a></p>
-      <p><a href="https://blogs.msdn.microsoft.com/mithuns/">my old blog</a></p>
+      <div class="quick-links">
+        <h2>Highlights</h2>
+        <p><a href="https://www.cloudskew.com">CloudSkew</a></p>
+        <p><a href="{{ "/topics/azure/" | relative_url }}">Azure topic hub</a></p>
+        <p><a href="{{ "/speaking/" | relative_url }}">Speaking profile</a></p>
+        <p><a href="https://blogs.msdn.microsoft.com/mithuns/">Legacy blog archive</a></p>
+      </div>
 
       <!--
         <p>{{ site.description | default: site.github.project_tagline }}</p>
@@ -54,7 +71,7 @@
         {% endif %}
         -->
     </header>
-    <section>
+    <section class="page-content">
 
       {{ content }}
 
@@ -67,9 +84,55 @@
         <p><small>Hosted on GitHub Pages &mdash; Theme by <a href="https://github.com/orderedlist">orderedlist</a></small></p>
         -->
 
+      <p class="footer-note">Built around practical writing on cloud architecture, developer productivity, and product experiments.</p>
     </footer>
   </div>
   <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
+  {% if page.url == "/" %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@graph": [
+        {
+          "@type": "WebSite",
+          "@id": "{{ "/" | absolute_url }}#website",
+          "url": "{{ "/" | absolute_url }}",
+          "name": "{{ site.title }}",
+          "description": {{ site.description | jsonify }}
+        },
+        {
+          "@type": "Person",
+          "@id": "{{ "/" | absolute_url }}#person",
+          "name": "{{ site.author.name }}",
+          "url": "{{ "/" | absolute_url }}",
+          "jobTitle": "Software architect, SaaS builder, and technical writer",
+          "homeLocation": "{{ site.author.location }}",
+          "sameAs": {{ site.social.links | jsonify }},
+          "knowsAbout": {{ site.expertise | jsonify }}
+        }
+      ]
+    }
+  </script>
+  {% endif %}
+  {% if page.url == "/about/" %}
+  <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "ProfilePage",
+      "url": "{{ page.url | absolute_url }}",
+      "name": "{{ page.title }}",
+      "mainEntity": {
+        "@type": "Person",
+        "@id": "{{ "/" | absolute_url }}#person",
+        "name": "{{ site.author.name }}",
+        "description": {{ site.description | jsonify }},
+        "homeLocation": "{{ site.author.location }}",
+        "sameAs": {{ site.social.links | jsonify }},
+        "knowsAbout": {{ site.expertise | jsonify }}
+      }
+    }
+  </script>
+  {% endif %}
   {% if site.google_analytics %}
   <script>
     (function (i, s, o, g, r, a, m) {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,8 +1,73 @@
 ---
 layout: default
 ---
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  <a href="{{ "/" | relative_url }}">Home</a>
+  <span aria-hidden="true">/</span>
+  <a href="{{ "/writing/" | relative_url }}">Writing</a>
+  {% if page.topic_hub_url and page.topic_hub_title %}
+  <span aria-hidden="true">/</span>
+  <a href="{{ page.topic_hub_url | relative_url }}">{{ page.topic_hub_title }}</a>
+  {% endif %}
+  <span aria-hidden="true">/</span>
+  <span>{{ page.title }}</span>
+</nav>
 <h1>{{ page.title }}</h1>
-<small>Published on {{ page.date | date_to_string }} by {{ site.author.name }}</small>
+<p class="post-meta">
+  Published on {{ page.date | date_to_string }} by {{ site.author.name }}
+  {% if page.last_reviewed %}
+  <br>
+  Last reviewed on {{ page.last_reviewed | date: "%-d %B %Y" }}
+  {% endif %}
+</p>
+{% if page.topic_hub_url and page.topic_hub_title %}
+<p class="topic-hub-link">Part of the <a href="{{ page.topic_hub_url | relative_url }}">{{ page.topic_hub_title }}</a> hub.</p>
+{% endif %}
 <hr>
 {{ content }}
+{% if page.related_posts and page.related_posts.size > 0 %}
 <hr>
+<div class="related-links">
+  <h2>Related reading</h2>
+  <ul class="post-list compact">
+    {% for related_url in page.related_posts %}
+      {% assign related_post = site.posts | where: "url", related_url | first %}
+      {% if related_post %}
+      <li>
+        <article>
+          <time datetime="{{ related_post.date | date: "%Y-%m-%d" }}">{{ related_post.date | date: "%d %b %Y" }}</time>
+          <a href="{{ related_post.url | relative_url }}">{{ related_post.title }}</a>
+        </article>
+      </li>
+      {% endif %}
+    {% endfor %}
+  </ul>
+</div>
+{% endif %}
+<hr>
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      {
+        "@type": "ListItem",
+        "position": 1,
+        "name": "Home",
+        "item": "{{ "/" | absolute_url }}"
+      },
+      {
+        "@type": "ListItem",
+        "position": 2,
+        "name": "Writing",
+        "item": "{{ "/writing/" | absolute_url }}"
+      },
+      {
+        "@type": "ListItem",
+        "position": 3,
+        "name": {{ page.title | jsonify }},
+        "item": "{{ page.url | absolute_url }}"
+      }
+    ]
+  }
+</script>

--- a/_posts/2019-02-14-awesome-azure-resources.md
+++ b/_posts/2019-02-14-awesome-azure-resources.md
@@ -1,7 +1,15 @@
 ---
 layout: post
 title: Awesome Azure Resources
+description: A curated collection of Azure documentation, tools, videos, blogs, pricing references, and starter resources.
 comments: false
+last_reviewed: 2026-07-22
+topic_hub_url: /topics/azure/
+topic_hub_title: Azure and cloud architecture
+related_posts:
+  - /2019/11/14/awesome-azure-devops-resources.html
+  - /2019/02/28/high-availability-azure-1-basics.html
+  - /2019/03/31/high-availability-azure-4-availability-zones.html
 ---
 My curated list of awesome azure-related resources (this will be a living document that I'll be updating frequently).
 

--- a/_posts/2019-02-28-high-availability-azure-1-basics.md
+++ b/_posts/2019-02-28-high-availability-azure-1-basics.md
@@ -1,7 +1,15 @@
 ---
 layout: post
 title: "High Availability in Azure: The basics"
+description: A foundational guide to Azure high availability covering geographies, regions, paired regions, and availability zones.
 comments: false
+last_reviewed: 2026-07-22
+topic_hub_url: /topics/azure/
+topic_hub_title: Azure and cloud architecture
+related_posts:
+  - /2019/03/31/high-availability-azure-4-availability-zones.html
+  - /2019/03/16/high-availability-azure-8-traffic.html
+  - /2019/02/14/awesome-azure-resources.html
 ---
 _Note: This blog post is part of a series centered around the topic of high availability in Azure:_
 

--- a/_posts/2019-03-16-high-availability-azure-8-traffic.md
+++ b/_posts/2019-03-16-high-availability-azure-8-traffic.md
@@ -1,7 +1,15 @@
 ---
 layout: post
 title: "High Availability in Azure: Traffic management"
+description: An overview of Azure Traffic Manager, what it does, what it does not do, and how it fits into high-availability architectures.
 comments: false
+last_reviewed: 2026-07-22
+topic_hub_url: /topics/azure/
+topic_hub_title: Azure and cloud architecture
+related_posts:
+  - /2019/02/28/high-availability-azure-1-basics.html
+  - /2019/03/31/high-availability-azure-4-availability-zones.html
+  - /2019/03/23/high-availability-azure-9-apps.html
 ---
 _Note: This blog post is part of a series centered around the topic of high availability in Azure:_
 

--- a/_posts/2019-03-31-high-availability-azure-4-availability-zones.md
+++ b/_posts/2019-03-31-high-availability-azure-4-availability-zones.md
@@ -1,7 +1,16 @@
 ---
 layout: post
 title: "High Availability in Azure: Availability Zones"
+description: A practical explanation of Azure Availability Zones, when to use them, how they compare with availability sets, and the tradeoffs involved.
 comments: false
+last_reviewed: 2026-07-22
+topic_hub_url: /topics/azure/
+topic_hub_title: Azure and cloud architecture
+related_posts:
+  - /2019/02/28/high-availability-azure-1-basics.html
+  - /2019/03/29/high-availability-azure-3-availability-sets.html
+  - /2019/03/16/high-availability-azure-8-traffic.html
+  - /2019/03/23/high-availability-azure-9-apps.html
 ---
 _Note: This blog post is part of a series centered around the topic of high availability in Azure:_
 

--- a/_posts/2019-06-19-speaking-engagements.md
+++ b/_posts/2019-06-19-speaking-engagements.md
@@ -1,7 +1,14 @@
 ---
 layout: post
 title: "Speaking Engagements"
+description: Talks, workshops, and recordings covering Azure, cloud architecture, identity, developer tooling, and product-building lessons.
 comments: false
+last_reviewed: 2026-07-22
+topic_hub_url: /speaking/
+topic_hub_title: Speaking
+related_posts:
+  - /2020/05/19/cloudskew-architecture.html
+  - /2019/02/14/awesome-azure-resources.html
 ---
 
 I often speak at meetup groups and tech conferences targeted at software developers and devops engineers. Just like my blog posts, my talks are mostly centered on open-source, cross-platform technologies driven by Microsoft _(.net core, asp.net core, azure cloud, powershell core, typescript etc)_.

--- a/_posts/2019-11-14-awesome-azure-devops-resources.md
+++ b/_posts/2019-11-14-awesome-azure-devops-resources.md
@@ -1,7 +1,14 @@
 ---
 layout: post
 title: Awesome Azure DevOps Resources
+description: A curated collection of Azure DevOps documentation, tools, videos, blogs, labs, and supporting resources.
 comments: false
+last_reviewed: 2026-07-22
+topic_hub_url: /topics/azure/
+topic_hub_title: Azure and cloud architecture
+related_posts:
+  - /2019/02/14/awesome-azure-resources.html
+  - /2019/06/19/speaking-engagements.html
 ---
 My curated list of awesome resources related to azure devops (this will be a living document that I'll be updating frequently).
 

--- a/_posts/2020-05-19-cloudskew-architecture.md
+++ b/_posts/2020-05-19-cloudskew-architecture.md
@@ -1,7 +1,15 @@
 ---
 layout: post
 title: How I built cloudskew.com
+description: A short architecture note and external deep-dive on how I built CloudSkew using Angular, ASP.NET Core, and Azure services.
 comments: false
+last_reviewed: 2026-07-22
+topic_hub_url: /topics/software-architecture/
+topic_hub_title: Software architecture
+related_posts:
+  - /2019/02/18/not-moving-web-apis-to-azure-functions.html
+  - /2019/06/19/speaking-engagements.html
+  - /2025/02/28/my-dev-setup.html
 ---
 
 I wrote about how I built [cloudskew.com](https://www.cloudskew.com) using Angular and AspNetCore on top of various Azure services. Read all about it [here](https://www.cloudskew.com/about/cloudskew-architecture.html).

--- a/_posts/2023-02-28-my-playbook.md
+++ b/_posts/2023-02-28-my-playbook.md
@@ -2,6 +2,13 @@
 layout: post
 title:  My playbook
 sitemap: false
+description: A living document of personal systems, routines, and mental models that have helped me grow in work and life.
+last_reviewed: 2026-07-22
+topic_hub_url: /topics/developer-productivity/
+topic_hub_title: Developer productivity
+related_posts:
+  - /2025/02/28/my-dev-setup.html
+  - /2019/03/08/dark-mode.html
 ---
 
 Based on my life experiences, I've cobbled together this playbook that has helped me in my growth/development. This is mostly for my own reference, but I hope it helps you too (disclaimer: I make no guarantees).

--- a/_posts/2025-02-28-my-dev-setup.md
+++ b/_posts/2025-02-28-my-dev-setup.md
@@ -1,7 +1,16 @@
 ---
 layout: post
 title: My local dev machine setup
+description: A practical snapshot of the tools, utilities, frameworks, and AI coding workflow I use across Windows, WSL, .NET, Azure, and TypeScript development.
+image: /images/my-pc.jpg
 comments: false
+last_reviewed: 2026-07-22
+topic_hub_url: /topics/developer-productivity/
+topic_hub_title: Developer productivity
+related_posts:
+  - /2023/02/28/my-playbook.html
+  - /2019/03/08/dark-mode.html
+  - /2018/11/13/awesome-dev-tools-that-I-rarely-use-now.html
 ---
 
 Recently, I had to replace my PC's old SSD, which meant I had to reinstall all my dev tools and utilities. I thought I'd document my setup here for posterity. This is a living document, and I'll keep updating it as my setup evolves.

--- a/_posts/2026-07-09-spc-concept1.md
+++ b/_posts/2026-07-09-spc-concept1.md
@@ -1,11 +1,15 @@
 ---
 layout: post
-title:  Concept 1 - Journal to comic
+title: Journal to comic - an AI comic journaling concept
+description: A product concept for turning daily journal entries into personalized comic strips generated from selfies, avatars, and AI-assisted storytelling.
+image: /images/comic-strip1.png
 comments: false
 unlisted: true
+topic_hub_url: /topics/ai-and-comics/
+topic_hub_title: AI and comic product ideas
 ---
 
-Turn your journal into daily comic strips.
+Turn your journal into daily comic strips, with AI helping translate your reflections into visual stories.
 
 ## Step 1: Upload selfies
 

--- a/_posts/2026-07-09-spc-concept2.md
+++ b/_posts/2026-07-09-spc-concept2.md
@@ -1,11 +1,15 @@
 ---
 layout: post
-title:  Concept 2 - Workplace comic strips
+title: Workplace comic strips - an AI internal communications concept
+description: A product concept for using AI-assisted comic strips to improve internal communications, reinforce team culture, and make workplace messaging more engaging.
+image: /images/workplace1.png
 comments: false
 unlisted: true
+topic_hub_url: /topics/ai-and-comics/
+topic_hub_title: AI and comic product ideas
 ---
 
-Use daily bite-sized comic strips to create cohesive teams. Drive internal workplace comms in an engaging way.
+Use daily bite-sized comic strips to create cohesive teams and make internal workplace communication more engaging.
 
 ## App form
 

--- a/about.md
+++ b/about.md
@@ -1,0 +1,37 @@
+---
+layout: default
+title: About
+description: About Mithun Shanbhag - a Bangalore-based software architect, SaaS builder, speaker, and technical writer focused on .NET, Azure, software architecture, and AI-assisted product ideas.
+permalink: /about/
+---
+<h1>About Mithun Shanbhag</h1>
+
+<p>I am a Bangalore-based software architect, SaaS builder, speaker, and technical writer. I spend most of my time building products, exploring better developer workflows, and writing down what I learn along the way.</p>
+
+<p>My writing usually sits at the intersection of <strong>.NET</strong>, <strong>Azure</strong>, <strong>software architecture</strong>, <strong>developer productivity</strong>, and <strong>AI-assisted product exploration</strong>.</p>
+
+<h2>What you will find here</h2>
+
+<ul>
+  <li>Practical writing on cloud architecture and Azure implementation tradeoffs</li>
+  <li>Notes from building products such as <a href="https://www.cloudskew.com">CloudSkew</a></li>
+  <li>Developer tooling, local setup, and productivity systems that have worked for me</li>
+  <li>Early product ideas and experiments around AI-assisted storytelling and comics</li>
+</ul>
+
+<h2>Where to start</h2>
+
+<ul>
+  <li><a href="{{ "/projects/" | relative_url }}">Projects</a> for product and experiment overviews</li>
+  <li><a href="{{ "/writing/" | relative_url }}">Writing</a> for the full archive and topic hubs</li>
+  <li><a href="{{ "/speaking/" | relative_url }}">Speaking</a> for talks, recordings, and workshop material</li>
+</ul>
+
+<h2>Profiles and contact</h2>
+
+<ul>
+  <li><a href="{{ site.author.linkedin }}">LinkedIn</a></li>
+  <li><a href="{{ site.author.github }}">GitHub</a></li>
+  <li><a href="{{ site.author.twitter }}">X</a></li>
+  <li><a href="https://www.cloudskew.com">CloudSkew</a></li>
+</ul>

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -8,7 +8,126 @@
     width: 980px;
   }
 
-  section {
+  .page-content {
     width: 620px;
+  }
+}
+
+.site-title {
+  margin-bottom: 0.35rem;
+  font-size: 1.8rem;
+  font-weight: 700;
+}
+
+.site-tagline,
+.footer-note {
+  color: #555;
+}
+
+.site-nav,
+.social-links,
+.cta-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  align-items: center;
+}
+
+.site-nav {
+  margin: 1rem 0 0.5rem;
+  font-weight: 600;
+}
+
+.social-links {
+  margin-bottom: 1rem;
+}
+
+.site-logo {
+  border-radius: 12px;
+  margin: 0.5rem 0 1.5rem;
+}
+
+.quick-links h2,
+.content-section h2,
+.related-links h2 {
+  margin-bottom: 0.6rem;
+}
+
+.page-content {
+  line-height: 1.65;
+}
+
+.hero {
+  margin-bottom: 2rem;
+}
+
+.hero h1 {
+  margin-bottom: 0.75rem;
+}
+
+.lede {
+  font-size: 1.05rem;
+  color: #333;
+}
+
+.content-section {
+  margin: 2rem 0;
+}
+
+.feature-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.feature-card {
+  padding: 1rem;
+  border: 1px solid #e2e2e2;
+  border-radius: 10px;
+  background: #fafafa;
+}
+
+.feature-card h3 {
+  margin-top: 0;
+  margin-bottom: 0.35rem;
+}
+
+.post-list {
+  margin: 0;
+  padding-left: 1.1rem;
+}
+
+.post-list li + li {
+  margin-top: 0.75rem;
+}
+
+.post-list article {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.post-list time,
+.post-meta,
+.breadcrumbs,
+.topic-hub-link {
+  color: #666;
+  font-size: 0.95rem;
+}
+
+.breadcrumbs {
+  margin-bottom: 1rem;
+}
+
+.breadcrumbs a,
+.topic-hub-link a {
+  color: inherit;
+}
+
+.related-links {
+  margin-top: 1.5rem;
+}
+
+@media print, screen and (min-width: 961px) {
+  .feature-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/google7e22ea2689ec1b26.html
+++ b/google7e22ea2689ec1b26.html
@@ -1,1 +1,5 @@
+---
+layout: null
+sitemap: false
+---
 google-site-verification: google7e22ea2689ec1b26.html

--- a/index.html
+++ b/index.html
@@ -1,15 +1,108 @@
 ---
 layout: default
-title: Blog
+title: Software architect, SaaS builder, and technical writer
+description: Bangalore-based software architect and builder sharing practical writing on .NET, Azure, software architecture, developer productivity, and AI-assisted product ideas.
 ---
-<h1>Latest blog posts</h1>
+<div class="hero">
+  <h1>Mithun Shanbhag is a software architect, SaaS builder, and technical writer.</h1>
+  <p class="lede">I build products, speak at developer events, and write about .NET, Azure, software architecture, developer productivity, and AI-assisted product ideas.</p>
+  <p class="cta-links">
+    <a href="{{ "/about/" | relative_url }}">About</a>
+    <a href="{{ "/projects/" | relative_url }}">Projects</a>
+    <a href="{{ "/writing/" | relative_url }}">Writing</a>
+    <a href="{{ "/speaking/" | relative_url }}">Speaking</a>
+  </p>
+</div>
 
-<!-- <ul> -->
-  {% for post in site.posts %}
-    {% unless post.unlisted %}
-      <!-- <li> -->
-        <p>[{{ post.date | date_to_string }}] <a href="{{ post.url }}">{{ post.title }}</a></p>
-      <!-- </li> -->
-    {% endunless %}
-  {% endfor %}
-<!-- </ul> -->
+<div class="content-section">
+  <h2>Selected projects</h2>
+  <div class="feature-grid">
+    <article class="feature-card">
+      <h3><a href="https://www.cloudskew.com">CloudSkew</a></h3>
+      <p>A browser-based cloud diagramming product, with architecture notes and product context captured in the writing archive.</p>
+      <p><a href="{{ "/2020/05/19/cloudskew-architecture.html" | relative_url }}">Read the architecture write-up</a></p>
+    </article>
+    <article class="feature-card">
+      <h3><a href="{{ "/2026/07/09/spc-concept1.html" | relative_url }}">Journal to comic</a></h3>
+      <p>An AI-assisted storytelling concept for turning daily journal entries into personalized comic strips.</p>
+    </article>
+    <article class="feature-card">
+      <h3><a href="{{ "/2026/07/09/spc-concept2.html" | relative_url }}">Workplace comic strips</a></h3>
+      <p>An internal communications concept for using short comics to reinforce team culture, safety, and workplace habits.</p>
+    </article>
+  </div>
+</div>
+
+<div class="content-section">
+  <h2>Explore by topic</h2>
+  <div class="feature-grid">
+    <article class="feature-card">
+      <h3><a href="{{ "/topics/azure/" | relative_url }}">Azure and cloud architecture</a></h3>
+      <p>High-availability series posts, architecture notes, and curated Azure resources.</p>
+    </article>
+    <article class="feature-card">
+      <h3><a href="{{ "/topics/software-architecture/" | relative_url }}">Software architecture</a></h3>
+      <p>Product architecture, API design choices, and system-level implementation notes.</p>
+    </article>
+    <article class="feature-card">
+      <h3><a href="{{ "/topics/developer-productivity/" | relative_url }}">Developer productivity</a></h3>
+      <p>Dev environment setup, productivity systems, and practical tooling notes.</p>
+    </article>
+    <article class="feature-card">
+      <h3><a href="{{ "/topics/ai-and-comics/" | relative_url }}">AI and comic product ideas</a></h3>
+      <p>Early product experiments at the intersection of AI workflows, storytelling, and product exploration.</p>
+    </article>
+  </div>
+</div>
+
+<div class="content-section">
+  <h2>Selected writing</h2>
+  <ul class="post-list">
+    <li>
+      <article>
+        <time datetime="2025-02-28">28 Feb 2025</time>
+        <a href="{{ "/2025/02/28/my-dev-setup.html" | relative_url }}">My local dev machine setup</a>
+      </article>
+    </li>
+    <li>
+      <article>
+        <time datetime="2020-05-19">19 May 2020</time>
+        <a href="{{ "/2020/05/19/cloudskew-architecture.html" | relative_url }}">How I built cloudskew.com</a>
+      </article>
+    </li>
+    <li>
+      <article>
+        <time datetime="2019-03-31">31 Mar 2019</time>
+        <a href="{{ "/2019/03/31/high-availability-azure-4-availability-zones.html" | relative_url }}">High Availability in Azure: Availability Zones</a>
+      </article>
+    </li>
+    <li>
+      <article>
+        <time datetime="2019-02-14">14 Feb 2019</time>
+        <a href="{{ "/2019/02/14/awesome-azure-resources.html" | relative_url }}">Awesome Azure Resources</a>
+      </article>
+    </li>
+  </ul>
+</div>
+
+<div class="content-section">
+  <h2>Speaking</h2>
+  <p>I speak about cloud architecture, Azure, developer tooling, and lessons learned while building products. The speaking page links to videos, slides, and workshop material.</p>
+  <p><a href="{{ "/speaking/" | relative_url }}">View speaking profile</a></p>
+</div>
+
+<div class="content-section">
+  <h2>Latest posts</h2>
+  <ul class="post-list">
+    {% for post in site.posts limit: 8 %}
+      {% unless post.unlisted %}
+      <li>
+        <article>
+          <time datetime="{{ post.date | date: "%Y-%m-%d" }}">{{ post.date | date: "%d %b %Y" }}</time>
+          <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+        </article>
+      </li>
+      {% endunless %}
+    {% endfor %}
+  </ul>
+</div>

--- a/projects.md
+++ b/projects.md
@@ -1,0 +1,36 @@
+---
+layout: default
+title: Projects
+description: Projects, experiments, and product concepts from Mithun Shanbhag, including CloudSkew and AI-assisted comic storytelling ideas.
+permalink: /projects/
+---
+<h1>Projects and experiments</h1>
+
+<p>This page highlights the products, prototypes, and experiments that connect the writing on this site to real-world product building.</p>
+
+<h2>CloudSkew</h2>
+
+<p><a href="https://www.cloudskew.com">CloudSkew</a> is a browser-based cloud diagramming product. I wrote a short architecture overview here and linked to the deeper product write-up hosted on the CloudSkew site.</p>
+
+<p><a href="{{ "/2020/05/19/cloudskew-architecture.html" | relative_url }}">Read the CloudSkew architecture note</a></p>
+
+<h2>AI-assisted comic product ideas</h2>
+
+<p>These are early-stage concepts exploring how AI can help with storytelling, personalization, and communication.</p>
+
+<ul class="post-list compact">
+  <li>
+    <article>
+      <a href="{{ "/2026/07/09/spc-concept1.html" | relative_url }}">Journal to comic</a>
+      <span>Turn daily journaling into personalized comic strips with avatars and AI-assisted storytelling.</span>
+    </article>
+  </li>
+  <li>
+    <article>
+      <a href="{{ "/2026/07/09/spc-concept2.html" | relative_url }}">Workplace comic strips</a>
+      <span>Use short comic strips to reinforce internal communications, morale, and workplace culture.</span>
+    </article>
+  </li>
+</ul>
+
+<p><a href="{{ "/topics/ai-and-comics/" | relative_url }}">Browse the AI and comics topic hub</a></p>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,7 @@
+---
+layout: null
+---
+User-agent: *
+Allow: /
+
+Sitemap: {{ "/sitemap.xml" | absolute_url }}

--- a/speaking.md
+++ b/speaking.md
@@ -1,0 +1,27 @@
+---
+layout: default
+title: Speaking
+description: Speaking profile for Mithun Shanbhag, including talks and workshops on Azure, cloud architecture, developer tooling, and product-building lessons.
+permalink: /speaking/
+---
+<h1>Speaking</h1>
+
+<p>I speak at developer meetups, workshops, and online events about Azure, cloud architecture, developer tooling, identity, and lessons learned while building products.</p>
+
+<h2>Representative topics</h2>
+
+<ul>
+  <li>High-availability architectures in Azure</li>
+  <li>CloudSkew architecture and product-building lessons</li>
+  <li>Azure DevOps workshops for .NET and Node.js developers</li>
+  <li>Identity, authentication, and authorization with OpenID Connect and OAuth2</li>
+  <li>Terraform on Azure, WSL internals, and developer productivity</li>
+</ul>
+
+<h2>Resources</h2>
+
+<ul>
+  <li><a href="{{ "/2019/06/19/speaking-engagements.html" | relative_url }}">Full speaking history</a></li>
+  <li><a href="https://www.slideshare.net/mithunshanbhag/presentations">Slides on SlideShare</a></li>
+  <li><a href="{{ site.author.twitter }}">Reach out on X</a> if you would like me to speak at your meetup, workshop, or conference</li>
+</ul>

--- a/topics/ai-and-comics.md
+++ b/topics/ai-and-comics.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: AI and comic product ideas
+description: Early product concepts from Mithun Shanbhag exploring AI-assisted comic storytelling, journaling, and internal communications.
+permalink: /topics/ai-and-comics/
+---
+<h1>AI and comic product ideas</h1>
+
+<p>This hub brings together early product explorations around AI-assisted storytelling, personalization, and workplace communication.</p>
+
+<ul class="post-list">
+  <li><article><a href="{{ "/2026/07/09/spc-concept1.html" | relative_url }}">Journal to comic - an AI comic journaling concept</a></article></li>
+  <li><article><a href="{{ "/2026/07/09/spc-concept2.html" | relative_url }}">Workplace comic strips - an AI internal communications concept</a></article></li>
+</ul>
+
+<p>For the broader product context, see the <a href="{{ "/projects/" | relative_url }}">projects page</a>.</p>

--- a/topics/azure.md
+++ b/topics/azure.md
@@ -1,0 +1,34 @@
+---
+layout: default
+title: Azure and cloud architecture
+description: Azure writing from Mithun Shanbhag, including high-availability guidance, curated Azure resources, and cloud architecture notes.
+permalink: /topics/azure/
+---
+<h1>Azure and cloud architecture</h1>
+
+<p>This hub brings together my writing on Azure architecture, reliability, platform services, and curated cloud resources.</p>
+
+<h2>High availability in Azure</h2>
+
+<ul class="post-list">
+  <li><article><a href="{{ "/2019/02/28/high-availability-azure-1-basics.html" | relative_url }}">High Availability in Azure: The basics</a></article></li>
+  <li><article><a href="{{ "/2019/03/29/high-availability-azure-3-availability-sets.html" | relative_url }}">High Availability in Azure: Availability Sets</a></article></li>
+  <li><article><a href="{{ "/2019/03/31/high-availability-azure-4-availability-zones.html" | relative_url }}">High Availability in Azure: Availability Zones</a></article></li>
+  <li><article><a href="{{ "/2019/03/02/high-availability-azure-5-storage.html" | relative_url }}">High Availability in Azure: Storage redundancies</a></article></li>
+  <li><article><a href="{{ "/2019/03/16/high-availability-azure-8-traffic.html" | relative_url }}">High Availability in Azure: Traffic management</a></article></li>
+  <li><article><a href="{{ "/2019/03/23/high-availability-azure-9-apps.html" | relative_url }}">High Availability in Azure: App Service, Function Apps</a></article></li>
+</ul>
+
+<h2>Curated resources</h2>
+
+<ul class="post-list">
+  <li><article><a href="{{ "/2019/02/14/awesome-azure-resources.html" | relative_url }}">Awesome Azure Resources</a></article></li>
+  <li><article><a href="{{ "/2019/11/14/awesome-azure-devops-resources.html" | relative_url }}">Awesome Azure DevOps Resources</a></article></li>
+</ul>
+
+<h2>Related architecture notes</h2>
+
+<ul class="post-list compact">
+  <li><article><a href="{{ "/2019/02/18/not-moving-web-apis-to-azure-functions.html" | relative_url }}">Why we're not moving our web APIs to Azure Functions yet</a></article></li>
+  <li><article><a href="{{ "/2020/05/19/cloudskew-architecture.html" | relative_url }}">How I built cloudskew.com</a></article></li>
+</ul>

--- a/topics/developer-productivity.md
+++ b/topics/developer-productivity.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Developer productivity
+description: Developer productivity writing from Mithun Shanbhag, including local setup notes, tooling, and personal systems for consistent execution.
+permalink: /topics/developer-productivity/
+---
+<h1>Developer productivity</h1>
+
+<p>This hub groups the posts that are most useful if you are interested in tooling, environment setup, productivity systems, and practical day-to-day developer workflows.</p>
+
+<ul class="post-list">
+  <li><article><a href="{{ "/2025/02/28/my-dev-setup.html" | relative_url }}">My local dev machine setup</a></article></li>
+  <li><article><a href="{{ "/2023/02/28/my-playbook.html" | relative_url }}">My playbook</a></article></li>
+  <li><article><a href="{{ "/2019/03/08/dark-mode.html" | relative_url }}">Dark Mode or: How I learnt to start worrying about my eyes</a></article></li>
+  <li><article><a href="{{ "/2018/11/13/awesome-dev-tools-that-I-rarely-use-now.html" | relative_url }}">Awesome dev tools that I rarely use now</a></article></li>
+</ul>

--- a/topics/software-architecture.md
+++ b/topics/software-architecture.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Software architecture
+description: Software architecture writing from Mithun Shanbhag, including product architecture notes, API design choices, and implementation tradeoffs.
+permalink: /topics/software-architecture/
+---
+<h1>Software architecture</h1>
+
+<p>This hub focuses on architecture decisions, product implementation notes, and the tradeoffs involved in building software systems.</p>
+
+<ul class="post-list">
+  <li><article><a href="{{ "/2020/05/19/cloudskew-architecture.html" | relative_url }}">How I built cloudskew.com</a></article></li>
+  <li><article><a href="{{ "/2019/02/18/not-moving-web-apis-to-azure-functions.html" | relative_url }}">Why we're not moving our web APIs to Azure Functions yet</a></article></li>
+  <li><article><a href="{{ "/2018/12/11/builtin-request-validators-aspnet-core-web-apis.html" | relative_url }}">Built-in request validators for ASP.NET Core Web APIs</a></article></li>
+</ul>
+
+<p>For cloud reliability and platform-specific Azure guidance, see the <a href="{{ "/topics/azure/" | relative_url }}">Azure and cloud architecture</a> hub.</p>

--- a/writing.md
+++ b/writing.md
@@ -1,0 +1,45 @@
+---
+layout: default
+title: Writing
+description: Writing archive from Mithun Shanbhag covering Azure, software architecture, developer productivity, and product exploration.
+permalink: /writing/
+---
+<h1>Writing archive</h1>
+
+<p>The writing archive is organized around practical topics: Azure and cloud architecture, software architecture, developer productivity, and product exploration.</p>
+
+<h2>Topic hubs</h2>
+
+<div class="feature-grid">
+  <article class="feature-card">
+    <h3><a href="{{ "/topics/azure/" | relative_url }}">Azure and cloud architecture</a></h3>
+    <p>High-availability patterns, Azure resources, and platform guidance.</p>
+  </article>
+  <article class="feature-card">
+    <h3><a href="{{ "/topics/software-architecture/" | relative_url }}">Software architecture</a></h3>
+    <p>Architecture notes from product building and implementation tradeoffs.</p>
+  </article>
+  <article class="feature-card">
+    <h3><a href="{{ "/topics/developer-productivity/" | relative_url }}">Developer productivity</a></h3>
+    <p>Tooling, systems, and setup notes for shipping consistently.</p>
+  </article>
+  <article class="feature-card">
+    <h3><a href="{{ "/topics/ai-and-comics/" | relative_url }}">AI and comic product ideas</a></h3>
+    <p>Early ideas that combine AI workflows with storytelling and communication.</p>
+  </article>
+</div>
+
+<h2>Latest posts</h2>
+
+<ul class="post-list">
+  {% for post in site.posts %}
+    {% unless post.unlisted %}
+    <li>
+      <article>
+        <time datetime="{{ post.date | date: "%Y-%m-%d" }}">{{ post.date | date: "%d %b %Y" }}</time>
+        <a href="{{ post.url | relative_url }}">{{ post.title }}</a>
+      </article>
+    </li>
+    {% endunless %}
+  {% endfor %}
+</ul>


### PR DESCRIPTION
## Summary
- turn the homepage into a stronger personal-brand landing page with clearer navigation, topic discovery, and project highlights
- add About, Projects, Writing, Speaking, and topic hub pages to improve topical organization and internal linking
- strengthen SEO signals with richer metadata, explicit `robots.txt`, person-centric structured data, breadcrumbs, related reading, and sitemap cleanup for the Google verification file

## Follow-up after merge
- submit `https://www.mithunshanbhag.com/sitemap.xml` in Google Search Console and Bing Webmaster Tools
- inspect the live homepage and a few key articles to confirm canonical and indexing behavior on the custom domain

## Notes
- the two SPC concept posts remain intentionally public, but they are now connected through the homepage, projects page, and the new AI/comics topic hub
- `git diff --check` passes
- a full local Jekyll build was not available in this session because Ruby is not installed locally and the Docker daemon could not be started from this environment